### PR TITLE
fix "did not find expected alphabetic or numeric character" on apply

### DIFF
--- a/manifeasts/deploy.yaml
+++ b/manifeasts/deploy.yaml
@@ -16,13 +16,13 @@ rules:
       - pods
       - events
     verbs:
-      - *
+      - "*"
   - apiGroups:
       - "carrier.ocgi.dev"
     resources:
-      - *
+      - "*"
     verbs:
-      - *
+      - "*"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
I tried the quickstart with minikube, but it failed with the following error, so I fixed it.

```
error: error parsing deploy.yaml: error converting YAML to JSON: yaml: line 13: did not find expected alphabetic or numeric character
```
