### PR TITLE
Remove state check before sync

### DIFF
--- a/pkg/controllers/gameservers/controller.go
+++ b/pkg/controllers/gameservers/controller.go
@@ -328,10 +328,6 @@ func (c *Controller) syncGameServer(key string) error {
 	if gs.DeletionTimestamp != nil {
 		c.portAllocator.Release(getOwner(gs), string(gs.UID), findPorts(gs))
 	}
-	if gs.Status.State == carrierv1alpha1.GameServerExited ||
-		gs.Status.State == carrierv1alpha1.GameServerFailed {
-		return nil
-	}
 	gsCopy := gs.DeepCopy()
 	if gs, err = c.syncGameServerDeletionTimestamp(gsCopy); err != nil {
 		if klog.V(5) {


### PR DESCRIPTION
We have check when it is `Starting` or `Running`. If we check, we can not delete `Failed` or `Exited` GameServer